### PR TITLE
xenmgr: Add back removed USB interfaces.

### DIFF
--- a/interfaces/xenmgr_vm.xml
+++ b/interfaces/xenmgr_vm.xml
@@ -464,6 +464,8 @@
     <property name="stubdom" type="b" access="readwrite"> <tp:docstring>Use stub domain to hide the device emulator.</tp:docstring> </property>
     <property name="stubdom-memory" type="i" access="readwrite"> <tp:docstring>Memory given to the stubdomain, in megabytes.</tp:docstring> </property>
     <property name="stubdom-cmdline" type="s" access="readwrite"> <tp:docstring>Cmdline to be appended to the stubdomain's default cmdline.</tp:docstring> </property>
+    <property name="usb-enabled" type="b" access="readwrite"><tp:docstring>Enables PV USB support.</tp:docstring></property>
+    <property name="usb-control" type="b" access="readwrite"><tp:docstring>Enables VM to talk to USB daemon</tp:docstring></property>
     <property name="usb-grab-devices" type="b" access="readwrite"><tp:docstring>Automatically assign all available USB devices upon this VM start.</tp:docstring></property>
     <property name="greedy-pciback-bind" type="b" access="readwrite"><tp:docstring>Bind passthrough pci devices to pciback early, to prevent their use by other VMs.</tp:docstring></property>
 


### PR DESCRIPTION
See relevant commit in manager.git:

These are used and probed by the toolstack:
```
xenmgr: RemoteErr {
    remoteErrorName = org.freedesktop.DBus.Error.Failed,
    remoteErrorBody = [
        DBusString property
            com.citrix.xenclient.xenmgr.vm.unrestricted.usb-control is
            not readable, or does not exist]
} while processing RPC
        org.freedesktop.DBus.Properties.Get
rpc-proxy: error: RemoteErr {
    remoteErrorName = org.freedesktop.DBus.Error.Failed,
    remoteErrorBody = [
        DBusString property
            com.citrix.xenclient.xenmgr.vm.unrestricted.usb-control is
            not readable, or does not exist
    ]
}
```